### PR TITLE
Use ENV to define HOME

### DIFF
--- a/hey_pj.rb
+++ b/hey_pj.rb
@@ -34,7 +34,7 @@ puts 'Adding git aliases (co, br, ci, and st)...'
 `git config --global alias.st status`
 
 puts 'Binding up/down (and ^P/^N) to search command history...'
-File.open('~/.bashrc', 'a') do |f|
+File.open(ENV['HOME'] + '/.bashrc', 'a') do |f|
   f.puts %q(bind '"\e[A": history-search-backward')
   f.puts %q(bind '"\e[B": history-search-forward')
   f.puts %q(bind '"\020": history-search-backward')


### PR DESCRIPTION
Sometimes seems to be issue with ~ because bash and such interpret that, but ruby by itself couldn't.  Using ENV with HOME (assuming HOME is defined) fixes this
